### PR TITLE
Instrument hog service with OpenTelemetry exporter

### DIFF
--- a/vision/hog/Dockerfile
+++ b/vision/hog/Dockerfile
@@ -10,8 +10,19 @@ COPY src/main/resources/lib/libopencv_java480.so /usr/lib
 ENV LD_LIBRARY_PATH /usr/lib
 
 # Copy the JAR file to the working directory
-COPY target/spring-first-app-0.0.1-SNAPSHOT.jar /app
+COPY target/spring-first-app-0.0.1-SNAPSHOT.jar .
+COPY opentelemetry-javaagent.jar .
 
+# Tracing
+ENV OTEL_TRACES_EXPORTER zipkin
+ENV OTEL_METRICS_EXPORTER none
+ENV OTEL_LOGS_EXPORTER none
+ENV OTEL_EXPORTER_ZIPKIN_ENDPOINT http://jaeger-with-cassandra-and-kafka-collector.observability.svc.cluster.local:9411/api/v2/spans
+
+# If testing locally with a Jaeger container, uncomment the following line
+# ENV OTEL_EXPORTER_ZIPKIN_ENDPOINT http://host.docker.internal:9411/api/v2/spans
+ENV JAVA_TOOL_OPTIONS="-javaagent:/app/opentelemetry-javaagent.jar -Dotel.exporter.otlp.protocol=http/protobuf"
+ENV OTEL_SERVICE_NAME="vision-hog"
 
 # Expose port 5000
 EXPOSE 5000


### PR DESCRIPTION
Edited /vision/hog/Dockerfile to include OpenTelemetry automatic instrumentation.
- Kubernetes in-cluster DNS is used to export traces to an existing Jaeger service
- For local testing, the OTEL_EXPORTER_ZIPKIN_ENDPOINT environment variable can be overriden with http://host.docker.internal:9411/api/v2/spans (or any appropriate Jaeger collector URL)
- The OpenTelemetry Jaeger exported is deprecated, so zipkin is used instead
- Currently, metrics and logs are not exported. However, this can change if needed

This PR also includes a .jar file containing the latest release of OpenTelemetry's Java agent.